### PR TITLE
Feature djbg003/administration site for models

### DIFF
--- a/apps/blog/admin.py
+++ b/apps/blog/admin.py
@@ -1,3 +1,4 @@
 from django.contrib import admin
+from .models import Post
 
-# Register your models here.
+admin.site.register(Post)

--- a/apps/blog/admin.py
+++ b/apps/blog/admin.py
@@ -1,4 +1,13 @@
 from django.contrib import admin
 from .models import Post
 
-admin.site.register(Post)
+
+@admin.register(Post)
+class PostAdmin(admin.ModelAdmin):
+    list_display = ["title", "slug", "author", "publish", "status"]
+    list_filter = ["status", "created", "publish", "author"]
+    search_fields = ["title", "body"]
+    prepopulated_fields = {"slug": ("title",)}
+    raw_id_fields = ["author"]
+    date_hierarchy = "publish"
+    ordering = ["status", "publish"]


### PR DESCRIPTION
### Administration site for models
An admin site is a web interface that allows site administrators to perform administration tasks, such as adding, editing or deleting site content. In Django, the admin site is available by default and can be customized to suit the specific needs of the site.

The code presented imports the Post model from the **models.py** file and registers it in the **admin site**. The **PostAdmin** class defines how the Post model will be displayed in the administration interface. The **list_display** attribute defines which fields will be displayed in the list of Post objects. The **list_filter** attribute defines which filters will be available in the sidebar of the administration interface, **search_fields** defines the fields that can be searched and **prepopulated_fields** is used to automatically populate the **slug** field based on the **title** field. **raw_id_fields** is a list of fields that allow you to search for foreign key references using a search interface instead of a drop-down list. **date_hierarchy** is the name of the date field that is used to aggregate the date hierarchy in the navigation sidebar, and **ordering** defines the order in which the objects in the list will be displayed.