### PR TITLE
fixed bug in URL pattern of the application syntax error

### DIFF
--- a/apps/blog/urls.py
+++ b/apps/blog/urls.py
@@ -5,5 +5,5 @@ app_name = "blog"
 
 urlpatterns = [
     path("", views.post_list, name="post_list"),
-    path("<int:id", views.post_detail, name="post_detail"),
+    path("<int:id>/", views.post_detail, name="post_detail"),
 ]


### PR DESCRIPTION
### Error during template rendering
The error occurs because the reverse URL of the post_list.html file does not work correctly. Specifically, the reverse URL of the 'post_detail' view cannot be resolved correctly.

The reverse URL on line 7 of the post_list.html file:
```python
{% url 'blog:post_detail' post.id %}
```
appears to be looking for a URL that matches the regular expression 'blog/[int:id\\\Z, but the URL being generated is 'blog/1'. The value '1' in this case is the value of the 'Post' template ID object.

To fix this error, I made sure that the URL pattern in the urls.py file exactly matches the reverse URL in the post_list.html file.

This is what I had in the url pattern:
```python
path("<int:id", views.post_detail, name="post_detail"),
```
When what I needed was this:
```python
path("<int:id>/", views.post_detail, name="post_detail"),
```
I made the change and it worked.