### PR TITLE
use of canonical URLs for models

### DIFF
--- a/apps/blog/models.py
+++ b/apps/blog/models.py
@@ -1,7 +1,7 @@
 from django.db import models
 from django.utils import timezone
 from django.contrib.auth.models import User
-
+from django.urls import reverse
 
 class PublishedManager(models.Manager):
     def get_queryset(self):
@@ -37,3 +37,7 @@ class Post(models.Model):
 
     def __str__(self):
         return self.title
+
+    def get_absolute_url(self):
+        return reverse("blog:post_detail",
+                       args=[self.id])

--- a/templates/post_list.html
+++ b/templates/post_list.html
@@ -6,7 +6,7 @@
   <h1>My Blog</h1>
   {% for post in posts %}
     <h2>
-      <a href="{% url 'blog:post_detail' post.id %}">
+      <a href="{{ post.get_absolute_url }}">
         {{ post.title }}
       </a>
     </h2>


### PR DESCRIPTION
### Use of canonical URLs for models
A canonical URL is a preferred URL for a webpage that helps to avoid duplicate content issues. It tells search engines which version of a webpage is the original and should be indexed, and can help improve search engine rankings.

I'm using canonical URLs to ensure that search engines recognize the main page for each piece of content on my website or application. This helps to avoid issues with duplicate content that can negatively affect search engine rankings. By specifying the canonical URL for each piece of content, I can tell search engines which version of the content is the most important and should be indexed. This can help improve the visibility and ranking of my website or application in search results.