### PR TITLE
adding pagination to the post list view

### DIFF
--- a/apps/blog/views.py
+++ b/apps/blog/views.py
@@ -22,4 +22,5 @@ def post_detail(request, year, month, day, post):
 class PostListView(ListView):
     queryset = Post.published.all()
     context_object_name = "posts"
+    paginate_by = 3
     template_name = "post_list.html"

--- a/templates/pagination.html
+++ b/templates/pagination.html
@@ -1,0 +1,13 @@
+<div class="pagination">
+  <span class="step-links">
+    {% if page.has_previous %}
+    <a href="?page={{ page.previous_page_number }}">Previous</a>
+    {% endif %}
+    <span class="current">
+      Page {{ page.number }} of {{ page.paginator.num_pages }}.
+    </span>
+    {% if page.has_next %}
+    <a href="?page={{ page.next_page_number }}">Next</a>
+    {% endif %}
+  </span>
+</div>

--- a/templates/post_list.html
+++ b/templates/post_list.html
@@ -15,4 +15,5 @@
     </p>
     {{ post.body|truncatewords:30|linebreaks }}
   {% endfor %}
+  {% include "pagination.html" with page=page_obj %}
 {% endblock %}


### PR DESCRIPTION
### Adding pagination to the post list view
When you start adding content to your blog, you can easily store tens or hundreds of posts in your database. Instead of displaying all the posts on a single page, you may want to split the list of posts across several pages and include navigation links to the different pages. This functionality is called pagination, and you can find it in almost every web application that displays long lists of items. For example, Google uses pagination to divide search results across multiple pages.
![pagination](https://hasura.io/blog/content/images/2019/11/google-pagination.png)
